### PR TITLE
fixed build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,21 @@
-
 buildscript {
     ext.cubaVersion = '7.1.2'
     repositories {
         maven {
-            url 'https://dl.bintray.com/cuba-platform/main'
+            url 'https://repo.cuba-platform.com/content/groups/work'
+            credentials {
+                username(rootProject.hasProperty('repoUser') ? rootProject['repoUser'] : 'cuba')
+                password(rootProject.hasProperty('repoPass') ? rootProject['repoPass'] : 'cuba123')
+            }
         }
-        jcenter()
     }
     dependencies {
         classpath "com.haulmont.gradle:cuba-plugin:$cubaVersion"
     }
+}
+
+plugins {
+    id "org.jetbrains.gradle.plugin.idea-ext" version "1.1.6"
 }
 
 def modulePrefix = 'petclinic'
@@ -46,7 +52,7 @@ def hsql = 'org.hsqldb:hsqldb:2.4.1'
 
 configure([globalModule, coreModule, webModule]) {
     apply(plugin: 'java')
-    apply(plugin: 'maven')
+    apply(plugin: 'maven-publish')
     apply(plugin: 'cuba')
 
     dependencies {


### PR DESCRIPTION
[source](https://doc.cuba-platform.com/manual-latest/access_to_repo.html): The Bintray Artifact Repository, available at the URL https://dl.bintray.com/cuba-platform, has already been closed.
- Replaced Bintray repo
- Added jetbrains idea plugin.
- Replaced plagin 'maven' to 'maven-publish'